### PR TITLE
Add function declarations to sound/pcm86.h

### DIFF
--- a/sound/pcm86.h
+++ b/sound/pcm86.h
@@ -142,6 +142,8 @@ void pcm86cs_enter_criticalsection();
 void pcm86cs_leave_criticalsection();
 
 void pcm86_reset(void);
+void pcm86gen_initialize(UINT rate);
+void pcm86gen_setvol(UINT vol);
 void pcm86gen_update(void);
 void pcm86_setpcmrate(REG8 val);
 void pcm86_setnextintr(void);


### PR DESCRIPTION
Avoids compilation error in newer compilers with -Werror=implicit-function-declaration enabled by default.