### PR TITLE
fix: correct SDL2 include path in compiler_base.h

### DIFF
--- a/compiler_base.h
+++ b/compiler_base.h
@@ -31,7 +31,7 @@
 #if USE_SDL >= 3
 #include <SDL3/SDL.h>
 #elif USE_SDL == 2
-#include <SDL3/SDL.h>
+#include <SDL2/SDL.h>
 #elif USE_SDL == 1
 #include <SDL/SDL.h>
 #else


### PR DESCRIPTION
Hi.
Nice to meet you

Even though it's for SDL2, it includes SDL3, causing the build to fail.
I have fixed it.

Thank you

---

初めまして。

SDL2 向けでも、SDL3 となり、ビルドが失敗していました。
修正しました。

よろしくお願いいたします。