### PR TITLE
fix build failure on Lakka building

### DIFF
--- a/io/np2sysp.c
+++ b/io/np2sysp.c
@@ -1,5 +1,5 @@
-#include <common/strres.h>
 #include <compiler.h>
+#include <common/strres.h>
 
 #if defined(OSLANG_UCS2)
 #include "oemtext.h"

--- a/io/printif.c
+++ b/io/printif.c
@@ -1,5 +1,5 @@
-#include "commng.h"
 #include "compiler.h"
+#include "commng.h"
 #include "cpucore.h"
 #include "iocore.h"
 #include "pccore.h"


### PR DESCRIPTION
Hello NP2kai projects!
This is my first PR on NP2kai, please let me know if this has wrong.

Lakka-v6.1 tried libretro NP2kai bump to 9e7df10, but build is failed with attached log.
[NP2kai-build-failure-log-on-Lakka.log](https://github.com/user-attachments/files/27502527/NP2kai-build-failure-log-on-Lakka.log)

There are 2 problems a) and b), both causes are seemed to same.

### a) ../io/np2sysp.c
```
In file included from ../io/np2sysp.c:1:
../common/strres.h:6:14: error: unknown type name 'UINT8'
    6 | extern const UINT8 str_utf8[3];
      |              ^~~~~
../common/strres.h:7:14: error: unknown type name 'UINT16'
    7 | extern const UINT16 str_ucs2[1];
      |              ^~~~~~
../common/strres.h:9:14: error: unknown type name 'OEMCHAR'
    9 | extern const OEMCHAR str_null[];
      |              ^~~~~~~
<and more>
```
`common/strres.h` wants to use `UINT8`, `UINT16`, `OEMCHAR` and more but these are defined yet at this time.
These are defied in [compiler_base.h](https://github.com/AZO234/NP2kai/blob/9e7df1075f45dc728063c88c3efdd09ad33f0136/compiler_base.h#L160) that is included from [compiler.h](https://github.com/AZO234/NP2kai/blob/9e7df1075f45dc728063c88c3efdd09ad33f0136/sdl/unix/compiler.h#L11),
but `compiler.h` is not included before `strres.h`.
https://github.com/AZO234/NP2kai/blob/9e7df1075f45dc728063c88c3efdd09ad33f0136/io/np2sysp.c#L1-L2
This is reason for build failure of a).
It can be fixed by changing the order of the includes.

### b) ../io/printif.c
```
In file included from ../io/printif.c:1:
../sdl/commng.h:48:3: error: unknown type name 'UINT'
   48 |   UINT connect;
      |   ^~~~
../sdl/commng.h:49:3: error: expected specifier-qualifier-list before 'UINT'
   49 |   UINT (*read)(COMMNG self, UINT8 *data);
      |   ^~~~
../sdl/commng.h:64:3: error: unknown type name 'UINT32'
   64 |   UINT32 size;
      |   ^~~~~~
<and more>
```
b) likes same as a).
`compiler.h` is not included before `commng.h`.
https://github.com/AZO234/NP2kai/blob/9e7df1075f45dc728063c88c3efdd09ad33f0136/io/printif.c#L1-L2
It also can be fixed by changing the order of the includes.

### build result with this PR.
Lakka build is passed with this PR's patch.
[NP2kai-build-passed-log-on-Lakka.log](https://github.com/user-attachments/files/27503741/NP2kai-build-passed-log-on-Lakka.log)

### Note.
This problem looks like similar with issue #181.
But I don't know same or not, sorry.

Thanks
ASAI, Shigeaki