### PR TITLE
libretro: hand libretro-common the frontend VFS

### DIFF
--- a/cbus/boardmo.c
+++ b/cbus/boardmo.c
@@ -119,7 +119,7 @@ static REG8 IOINPCALL opn_i18a(UINT port) {
 		return(fmboard_getjoy(&g_opna[0]));
 	}
 	else if (addr < 0x10) {
-		return(psggen_getreg(&g_opna[0], addr));
+		return(psggen_getreg(&g_opna[0].psg, addr));
 	}
 	(void)port;
 	return(g_opna[0].s.data);
@@ -157,7 +157,7 @@ static const IOOUT opl_o[4] = {
 static const IOINP opl_i[4] = {
 			opl_i288,	opl_i28a,	opl_i28c,		opl_i28e};
 
-static void psgpanset(OPNA* psg) {
+static void psgpanset(PSGGEN psg) {
 	// SSG‚ÍLŒÅ’è
 	psggen_setpan(psg, 0, 2);
 	psggen_setpan(psg, 1, 2);
@@ -193,14 +193,14 @@ void boardmo_reset(const NP2CFG *pConfig) {
 }
 
 void boardmo_bind(void) {
-	psgpanset(&g_opna[0]);
+	psgpanset(&g_opna[0].psg);
 //	fmboard_fmrestore(0, 0);
 	opngen_setreg(&g_opna[0].opngen, 0, 0xb4, 1 << 6);
 	opngen_setreg(&g_opna[0].opngen, 0, 0xb5, 1 << 6);
 	opngen_setreg(&g_opna[0].opngen, 0, 0xb6, 1 << 6);
-	psggen_restore(&g_opna[0].opngen);
+	psggen_restore(&g_opna[0].psg);
 	sound_streamregist(&g_opna[0].opngen, (SOUNDCB)opngen_getpcm);
-	sound_streamregist(&g_opna[0].opngen, (SOUNDCB)psggen_getpcm);
+	sound_streamregist(&g_opna[0].psg, (SOUNDCB)psggen_getpcm);
 	cbuscore_attachsndex(0x188 - g_opna[0].s.base, opn_o, opn_i);
 	cbuscore_attachsndex(0x288, opl_o, opl_i);
 /*

--- a/sdl/libretro/libretro.c
+++ b/sdl/libretro/libretro.c
@@ -16,6 +16,8 @@
 #include "libretro_params.h"
 #include "libretro_core_options.h"
 #include "file_stream.h"
+#include "file_path.h"
+#include "retro_dirent.h"
 
 #include <compiler.h>//required to prevent missing type errors
 #include <sound/beep.h>
@@ -856,6 +858,7 @@ void lowerstring(char* str)
 void retro_set_environment(retro_environment_t cb)
 {
    struct retro_log_callback logging;
+   struct retro_vfs_interface_info vfs_iface_info;
    BOOL allow_no_game = true;
 
    environ_cb = cb;
@@ -864,6 +867,20 @@ void retro_set_environment(retro_environment_t cb)
    //environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_rom);
 
    environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &allow_no_game);
+
+   /* The core needs the full path to its disk images, and on Android that path
+    * is a Storage Access Framework content:// URI, which no C library call can
+    * open. Hand libretro-common the frontend's VFS so that dosio.c - which
+    * already goes through filestream/retro_dirent - opens those paths through
+    * the frontend instead. Each init checks the version it needs itself. */
+   vfs_iface_info.required_interface_version = 3;
+   vfs_iface_info.iface                      = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
+   {
+      filestream_vfs_init(&vfs_iface_info);
+      path_vfs_init(&vfs_iface_info);
+      dirent_vfs_init(&vfs_iface_info);
+   }
 
    libretro_set_core_options(environ_cb);
 }


### PR DESCRIPTION
Fixes #216.

**What this does**

The core sets `need_fullpath`, so it opens its disk images itself. On Android the path the frontend passes is a Storage Access Framework `content://` URI, which no C library call can resolve, so nothing picked through SAF loads.

Nearly all of the work for this is already in the tree: under `__LIBRETRO__`, `FILEH` is an `RFILE *` and `sdl/dosio.c` goes through `filestream_*`, `path_is_directory` and `retro_opendir` throughout. What was missing is the handshake — without it libretro-common quietly keeps using its own stdio implementation. So the first commit adds, in `retro_set_environment`:

```c
vfs_iface_info.required_interface_version = 3;
vfs_iface_info.iface                      = NULL;
if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
{
   filestream_vfs_init(&vfs_iface_info);
   path_vfs_init(&vfs_iface_info);
   dirent_vfs_init(&vfs_iface_info);
}
```

Each of the three checks the interface version it needs on its own, so a frontend that offers less than v3 (or none at all) simply keeps the existing fallback — nothing else in the core changes.

**The second commit fixes the build on GCC 14**

`cbus/boardmo.c` hands `psggen_getreg`, `psggen_setpan` and `psggen_restore` the whole `OPNA`, or its `OPNGEN`, where every other board passes `&opna->psg`. GCC 14 makes `-Wincompatible-pointer-types` an error, so the file no longer compiles at all — but the mismatch is not new, the calls have been reading and writing the wrong struct all along. The `sound_streamregist` next to them has the same mistake and never warned, because the callback is cast to `SOUNDCB` first, so `psggen_getpcm` has been generating PSG output from an `OPNGEN`. All of them now point at the PSG state, matching `opna.c` and `amd98.c`.

**Testing**

Built for aarch64 Linux with an unpatched GCC 14 (no warning overrides) and loaded in RetroArch, which confirms the handshake in its log — `[Environ] GET_VFS_INTERFACE. Core requested version >= V3, providing V3.` — after which every `file_open`/`file_read`/directory scan in the core runs through the frontend. `Ascend (2022-05-28)(Inufuto)(JP).d88` runs with no errors. Note that the VFS is not a path only Android exercises: once initialized, *all* file access goes through it on every platform, so ordinary local-path use is itself the regression test.

The same change is up as libretro/NP2kai#69 for the fork the libretro buildbot builds; this one is so the two do not drift.